### PR TITLE
Data usability report UAT Remediation

### DIFF
--- a/ckanext/qa/reports.py
+++ b/ckanext/qa/reports.py
@@ -39,6 +39,7 @@ def openness_index(include_sub_organizations=False):
         pkgs = model.Session.query(model.Package) \
                     .filter_by(owner_org=org.id) \
                     .filter_by(state='active') \
+                    .filter_by(private=False) \
                     .all()
         for pkg in pkgs:
             try:
@@ -120,6 +121,7 @@ def openness_for_organization(organization=None, include_sub_organizations=False
         pkgs = model.Session.query(model.Package) \
                     .filter_by(owner_org=org.id) \
                     .filter_by(state='active') \
+                    .filter_by(private=False) \
                     .all()
         num_packages += len(pkgs)
         for pkg in pkgs:

--- a/ckanext/qa/templates/report/openness.html
+++ b/ckanext/qa/templates/report/openness.html
@@ -42,8 +42,8 @@
           {% for n in range(6) %}
             <td>{{ row.get(n|string, 0) }}</td>
           {% endfor %}
-          <td>{{ row['total_stars'] }}</td>
-          <td>{{ row['average_stars'] }}</td>
+          <td>{{ row[_('total_stars')] }}</td>
+          <td>{{ row[_('average_stars')] }}</td>
         </tr>
       {% endfor %}
     </tbody>
@@ -52,8 +52,8 @@
 {% else %}
 
   <ul>
-    <li>{% trans %}Average score{% endtrans %}: {{ c.data['average_stars'] }}</li>
-    <li>{% trans %}Total stars{% endtrans %}: {{ c.data['total_stars'] }}</li>
+    <li>{% trans %}Average score{% endtrans %}: {{ c.data[_('average_stars')] }}</li>
+    <li>{% trans %}Total stars{% endtrans %}: {{ c.data[_('total_stars')] }}</li>
     <li>{% trans %}Datasets given a score{% endtrans %}: {{ c.data['num_packages_scored'] }} / {{ c.data['num_packages'] }}</li>
     <li>{% trans %}Score frequencies{% endtrans %}:
       <table class="table table-striped table-bordered table-condensed">


### PR DESCRIPTION
The following changes were implemented from the stories below for the data usability report.

https://salsadigital.atlassian.net/browse/DQL2-68: Average score and Total Ticks are not displayed
- Implemented number 2. Average score and total ticks are calculated and displayed on the report

https://salsadigital.atlassian.net/browse/DQL2-69: Private datasets are also displayed in the datausability report
- Private datasets are not displayed on the report

Ready for review
cc. @william-dutton-dsiti @ThrawnCA 