### PR TITLE
Develop to master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,11 @@
 #based on https://raw.githubusercontent.com/ckan/ckanext-scheming/master/.github/workflows/test.yml
 # alternative https://github.com/ckan/ckan/blob/master/contrib/cookiecutter/ckan_extension/%7B%7Bcookiecutter.project%7D%7D/.github/workflows/test.yml
 name: Tests
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    branches:
+      - master
 
 jobs:
   test:

--- a/ckanext/qa/i18n/en_AU/LC_MESSAGES/ckanext-qa.po
+++ b/ckanext/qa/i18n/en_AU/LC_MESSAGES/ckanext-qa.po
@@ -18,14 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.3.4\n"
 
-#: ckanext/qa/reports.py:83 ckanext/qa/reports.py:89 ckanext/qa/reports.py:150
-msgid "total_stars"
-msgstr "total_ticks"
-
-#: ckanext/qa/reports.py:84 ckanext/qa/reports.py:90 ckanext/qa/reports.py:151
-msgid "average_stars"
-msgstr "average_ticks"
-
 #: ckanext/qa/reports.py:165
 msgid "openness"
 msgstr "data_usability_rating"

--- a/ckanext/qa/lib.py
+++ b/ckanext/qa/lib.py
@@ -90,7 +90,7 @@ def munge_format_to_be_canonical(format_name):
 
 
 def create_qa_update_package_task(package, queue):
-    compat_enqueue('qa.update_package', tasks.update_package, queue, None, {'package_id': package.id})
+    compat_enqueue('qa.update_package', tasks.update_package, queue, kwargs={'package_id': package.id})
     log.debug('QA of package put into celery queue %s: %s',
               queue, package.name)
 
@@ -101,7 +101,7 @@ def create_qa_update_task(resource, queue):
     else:
         package = resource.package
 
-    compat_enqueue('qa.update', tasks.update, queue, None, {'resource_id': resource.id})
+    compat_enqueue('qa.update', tasks.update, queue, kwargs={'resource_id': resource.id})
 
     log.debug('QA of resource put into celery queue %s: %s/%s url=%r',
               queue, package.name, resource.id, resource.url)

--- a/ckanext/qa/lib.py
+++ b/ckanext/qa/lib.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 _RESOURCE_FORMAT_SCORES = None
 
 
-def compat_enqueue(name, fn, queue, args=None):
+def compat_enqueue(name, fn, queue, args=None, kwargs=None):
 
     u'''
     Enqueue a background job using Celery or RQ.
@@ -24,7 +24,7 @@ def compat_enqueue(name, fn, queue, args=None):
         # Try to use RQ
         from ckan.plugins.toolkit import enqueue_job
         nice_name = name + " " + args[1] if (len(args) >= 2) else name
-        enqueue_job(fn, args=args, queue=queue, title=nice_name)
+        enqueue_job(fn, args=args, kwargs=kwargs, queue=queue, title=nice_name)
     except ImportError:
         # Fallback to Celery
         import uuid
@@ -90,7 +90,7 @@ def munge_format_to_be_canonical(format_name):
 
 
 def create_qa_update_package_task(package, queue):
-    compat_enqueue('qa.update_package', tasks.update_package, queue, args=[package.id])
+    compat_enqueue('qa.update_package', tasks.update_package, queue, None, {'package_id': package.id})
     log.debug('QA of package put into celery queue %s: %s',
               queue, package.name)
 
@@ -101,7 +101,7 @@ def create_qa_update_task(resource, queue):
     else:
         package = resource.package
 
-    compat_enqueue('qa.update', tasks.update, queue, args=[resource.id])
+    compat_enqueue('qa.update', tasks.update, queue, None, {'resource_id': resource.id})
 
     log.debug('QA of resource put into celery queue %s: %s/%s url=%r',
               queue, package.name, resource.id, resource.url)

--- a/ckanext/qa/lib.py
+++ b/ckanext/qa/lib.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 _RESOURCE_FORMAT_SCORES = None
 
 
-def compat_enqueue(name, fn, queue, args=None, kwargs=None):
+def compat_enqueue(name, fn, queue, args=[], kwargs={}):
 
     u'''
     Enqueue a background job using Celery or RQ.

--- a/ckanext/qa/reports.py
+++ b/ckanext/qa/reports.py
@@ -84,14 +84,14 @@ def openness_index(include_sub_organizations=False):
         row = OrderedDict((
             ('organization_title', results[org_name]['organization_title']),
             ('organization_name', org_name),
-            (_('total_stars'), total_stars),
-            (_('average_stars'), average_stars),
+            ('total_stars', total_stars),
+            ('average_stars', average_stars),
         ))
         row.update(jsonify_counter(org_counts['score_counts']))
         table.append(row)
 
-    table.sort(key=lambda x: (-x[_('total_stars')],
-                              -x[_('average_stars')]))
+    table.sort(key=lambda x: (-x['total_stars'],
+                              -x['average_stars']))
 
     # Get total number of packages & resources
     num_packages = model.Session.query(model.Package)\
@@ -152,8 +152,8 @@ def openness_for_organization(organization=None, include_sub_organizations=False
 
     return {'table': rows,
             'score_counts': jsonify_counter(score_counts),
-            _('total_stars'): total_stars,
-            _('average_stars'): average_stars,
+            'total_stars': total_stars,
+            'average_stars': average_stars,
             'num_packages_scored': len(rows),
             'num_packages': num_packages,
             }
@@ -167,7 +167,7 @@ def openness_report_combinations():
 
 
 openness_report_info = {
-    'name': _('openness'),
+    'name': 'openness',
     'title': _('Openness (Five Stars)'),
     'description': _('Datasets graded on Tim Berners Lees\' Five Stars of Openness - openly licensed,'
                      ' openly accessible, structured, open format, URIs for entities, linked.'),

--- a/ckanext/qa/tasks.py
+++ b/ckanext/qa/tasks.py
@@ -103,7 +103,7 @@ def load_translations(lang):
     registry.register(translator, fakepylons.translator)
 
 
-def update_package(package_id):
+def update_package(ckan_ini_filepath=None, package_id=None):
     """
     Given a package, calculates an openness score for each of its resources.
     It is more efficient to call this than 'update' for each resource.
@@ -139,7 +139,7 @@ def update_package_(package_id):
     _update_search_index(package.id)
 
 
-def update(resource_id):
+def update(ckan_ini_filepath=None, resource_id=None):
     """
     Given a resource, calculates an openness score.
 

--- a/ckanext/qa/templates/report/openness.html
+++ b/ckanext/qa/templates/report/openness.html
@@ -37,13 +37,13 @@
     <tbody>
       {% for row in c.data['table'] %}
         <tr>
-          <td>{{ h.link_to(row['organization_title'], h.report__relative_url_for(organization=row['organization_name'])) }}</td>
+          <td>{{ h.link_to(row['organization_title'], h.url_for('report.org', report_name='openness', organization=row['organization_name'])) }}</td>
           <td>{{ row.get('null', 0) }}</td>
           {% for n in range(6) %}
             <td>{{ row.get(n|string, 0) }}</td>
           {% endfor %}
-          <td>{{ row[_('total_stars')] }}</td>
-          <td>{{ row[_('average_stars')] }}</td>
+          <td>{{ row['total_stars'] }}</td>
+          <td>{{ row['average_stars'] }}</td>
         </tr>
       {% endfor %}
     </tbody>
@@ -52,8 +52,8 @@
 {% else %}
 
   <ul>
-    <li>{% trans %}Average score{% endtrans %}: {{ c.data[_('average_stars')] }}</li>
-    <li>{% trans %}Total stars{% endtrans %}: {{ c.data[_('total_stars')] }}</li>
+    <li>{% trans %}Average score{% endtrans %}: {{ c.data['average_stars'] }}</li>
+    <li>{% trans %}Total stars{% endtrans %}: {{ c.data['total_stars'] }}</li>
     <li>{% trans %}Datasets given a score{% endtrans %}: {{ c.data['num_packages_scored'] }} / {{ c.data['num_packages'] }}</li>
     <li>{% trans %}Score frequencies{% endtrans %}:
       <table class="table table-striped table-bordered table-condensed">

--- a/ckanext/qa/templates/report/openness.html
+++ b/ckanext/qa/templates/report/openness.html
@@ -94,7 +94,7 @@
           <td>{{h.link_to(row['dataset_title'], '/dataset/%s' % row['dataset_name']) }}</td>
           <td>{{row['dataset_notes'] }}</td>
           {% if c.options['include_sub_organizations'] %}
-            <td>{{ h.link_to(row['organization_title'], h.report__relative_url_for(organization=row['organization_name'])) }}</td>
+            <td>{{ h.link_to(row['organization_title'], h.url_for('report.org', report_name='openness', organization=row['organization_name'])) }}</td>
           {% endif %}
           <td>{{ row['openness_score'] }}</td>
           <td class="js-tooltip" title="{{ row['openness_score_reason'] }}">{{ h.truncate(row['openness_score_reason'], 150) }}</td>


### PR DESCRIPTION
- restore optional task parameter for backwards compatibility
- don't localise internal keys, only outputs
- generate URL from full route instead of relying on relative path