### PR TITLE
Bump progressbar

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 xlrd==1.1.0
 #python-magic==0.4.15 #in ckancore
 messytables==0.15.2
-progressbar==2.3
+progressbar==2.5
 #SQLAlchemy>=0.6.6 #in ckancore
 #requests==2.11.1 #in ckancore
 six>=1.0.0 #in ckancore


### PR DESCRIPTION
Building the project in lagoon environment complains of the `progressbar` version
```
#0 51.07 Collecting progressbar==2.3
#0 51.11   Downloading progressbar-2.3.tar.gz (9.4 kB)
#0 51.26   Preparing metadata (setup.py): started
#0 51.65   Preparing metadata (setup.py): finished with status 'error'
#0 51.66   error: subprocess-exited-with-error
#0 51.66   
#0 51.66   × python setup.py egg_info did not run successfully.
#0 51.66   │ exit code: 1
#0 51.66   ╰─> [12 lines of output]
#0 51.66       Traceback (most recent call last):
#0 51.66         File "<string>", line 2, in <module>
#0 51.66         File "<pip-setuptools-caller>", line 34, in <module>
#0 51.66         File "/tmp/pip-install-y9cub49z/progressbar_cff8c6c5a0e24d2da9a33dbfbbbf7a54/setup.py", line 5, in <module>
#0 51.66           import progressbar
#0 51.66         File "/tmp/pip-install-y9cub49z/progressbar_cff8c6c5a0e24d2da9a33dbfbbbf7a54/progressbar/__init__.py", line 59, in <module>
#0 51.66           from progressbar.widgets import *
#0 51.66         File "/tmp/pip-install-y9cub49z/progressbar_cff8c6c5a0e24d2da9a33dbfbbbf7a54/progressbar/widgets.py", line 121, in <module>
#0 51.66           class FileTransferSpeed(Widget):
#0 51.66         File "/usr/local/lib/python3.8/abc.py", line 85, in __new__
#0 51.66           cls = super().__new__(mcls, name, bases, namespace, **kwargs)
#0 51.66       ValueError: 'format' in __slots__ conflicts with class variable
#0 51.66       [end of output]
```
Upgrading to 2.5 is fixing this issue