### PR TITLE
QOL-9055 prepare for Amazon Linux 2

### DIFF
--- a/ckanext/qa/bin/migrate_task_status.py
+++ b/ckanext/qa/bin/migrate_task_status.py
@@ -11,8 +11,8 @@ import logging
 import json
 import datetime
 
-import common
-from running_stats import StatsList
+from . import common
+from .running_stats import StatsList
 
 # pip install 'ProgressBar==2.3'
 from progressbar import ProgressBar, Percentage, Bar, ETA

--- a/ckanext/qa/bin/running_stats.py
+++ b/ckanext/qa/bin/running_stats.py
@@ -6,7 +6,7 @@ StatsList - when you also want to remember an ID associated with each incidence
 
 Examples:
 
-from running_stats import StatsCount
+from .running_stats import StatsCount
 package_stats = StatsCount()
 for package in packages:
     if package.enabled:
@@ -18,7 +18,7 @@ print(package_stats.report())
 > deleted: 30
 > not deleted: 70
 
-from running_stats import StatsList
+from .running_stats import StatsList
 package_stats = StatsList()
 for package in packages:
     if package.enabled:

--- a/ckanext/qa/cli/click_cli.py
+++ b/ckanext/qa/cli/click_cli.py
@@ -1,7 +1,8 @@
 # encoding: utf-8
 
 import click
-import commands
+
+from . import commands
 
 
 def get_commands():

--- a/ckanext/qa/lib.py
+++ b/ckanext/qa/lib.py
@@ -8,7 +8,7 @@ import six
 
 from ckan.plugins.toolkit import check_ckan_version, config
 
-import tasks
+from . import tasks
 
 log = logging.getLogger(__name__)
 

--- a/ckanext/qa/tests/mock_remote_server.py
+++ b/ckanext/qa/tests/mock_remote_server.py
@@ -6,8 +6,9 @@ from contextlib import contextmanager
 from threading import Thread
 from time import sleep
 from wsgiref.simple_server import make_server
-import urllib2
 import six
+from six.moves import reduce
+from six.moves.urllib.request import urlopen
 import socket
 
 
@@ -20,7 +21,7 @@ class MockHTTPServer(object):
     a separate thread, eg::
 
         >>> with MockTestServer().serve() as server_address:
-        ...     urllib2.urlopen(server_address)
+        ...     urlopen(server_address)
         ...
 
     Subclass this and override __call__ to provide your own WSGI handler function.
@@ -38,7 +39,7 @@ class MockHTTPServer(object):
         This uses context manager to make sure the server is stopped::
 
             >>> with MockTestServer().serve() as addr:
-            ...     print(urllib2.urlopen('%s/?content=hello+world').read())
+            ...     print(urlopen('%s/?content=hello+world').read())
             ...
             'hello world'
         """
@@ -69,7 +70,7 @@ class MockHTTPServer(object):
             # call completes. Set a very small timeout as we don't actually need to
             # wait for a response. We don't care about exceptions here either.
             try:
-                urllib2.urlopen("http://%s:%s/" % (host, port), timeout=0.01)
+                urlopen("http://%s:%s/" % (host, port), timeout=0.01)
             except Exception:
                 pass
 
@@ -81,8 +82,8 @@ class MockHTTPServer(object):
         called and its return value used.
         """
         modpath, var = varspec.split(':')
-        mod = six.moves.reduce(getattr, modpath.split('.')[1:], __import__(modpath))
-        var = six.moves.reduce(getattr, var.split('.'), mod)
+        mod = reduce(getattr, modpath.split('.')[1:], __import__(modpath))
+        var = reduce(getattr, var.split('.'), mod)
         try:
             return var()
         except TypeError:

--- a/ckanext/qa/tests/test_link_checker.py
+++ b/ckanext/qa/tests/test_link_checker.py
@@ -3,7 +3,7 @@
 import logging
 from functools import wraps
 import json
-from urllib import urlencode
+from six.moves.urllib.parse import urlencode
 from nose.tools import assert_in
 from nose.tools import assert_equal
 

--- a/ckanext/qa/tests/test_link_checker.py
+++ b/ckanext/qa/tests/test_link_checker.py
@@ -7,10 +7,10 @@ from urllib import urlencode
 from nose.tools import assert_in
 from nose.tools import assert_equal
 
-import ckan.tests.helpers as helpers
+from ckan.tests import helpers
 from ckanext.archiver.tasks import update_package
 
-from mock_remote_server import MockEchoTestServer
+from .mock_remote_server import MockEchoTestServer
 
 # enable celery logging for when you run nosetests -s
 log = logging.getLogger('ckanext.archiver.tasks')

--- a/ckanext/qa/tests/test_tasks.py
+++ b/ckanext/qa/tests/test_tasks.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import requests
 import logging
 from six.moves.urllib.parse import quote
@@ -6,9 +8,7 @@ import datetime
 from nose.tools import assert_equal
 from nose.plugins.skip import SkipTest
 from ckan import model
-from ckan.logic import get_action
-from ckan import plugins as p
-import ckan.lib.helpers as ckan_helpers
+from ckan.plugins.toolkit import check_ckan_version, get_action, h
 try:
     from ckan.tests.helpers import reset_db
     from ckan.tests import factories as ckan_factories
@@ -53,7 +53,7 @@ ckanext.qa.tasks.sniff_file_format = mock_sniff_file_format
 def set_sniffed_format(format_name):
     global sniffed_format
     if format_name:
-        format_tuple = ckan_helpers.resource_formats().get(format_name.lower())
+        format_tuple = h.resource_formats().get(format_name.lower())
         sniffed_format = {'format': format_tuple[1]}
     else:
         sniffed_format = None
@@ -213,7 +213,7 @@ class TestResourceScore():
 
     def test_by_format_field_excel(self):
         set_sniffed_format(None)
-        if p.toolkit.check_ckan_version(max_version='2.4.99'):
+        if check_ckan_version(max_version='2.4.99'):
             raise SkipTest
         result = resource_score(_test_resource(format='Excel'))
         assert_equal(result['format'], 'XLS')

--- a/ckanext/qa/tests/test_tasks.py
+++ b/ckanext/qa/tests/test_tasks.py
@@ -1,6 +1,6 @@
 import requests
 import logging
-import urllib
+from six.moves.urllib.parse import quote
 import datetime
 
 from nose.tools import assert_equal
@@ -152,7 +152,7 @@ class TestResourceScore():
     def _set_task_status(cls, task_type, task_status_str):
         url = '%s/set_task_status/%s/%s' % (cls.fake_ckan_url,
                                             task_type,
-                                            urllib.quote(task_status_str))
+                                            quote(task_status_str))
         res = requests.get(url)
         assert res.status_code == 200
 


### PR DESCRIPTION
- Make relative imports explicit so Py3 is happy
- Use 'six' for Python 2/3 compatibility in tests
- Improve use of CKAN toolkit API