### PR TITLE
[QOL-9055] downgrade xlrd to keep supporting XLSX

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-xlrd==2.0.1
+xlrd==1.2.0
 #python-magic==0.4.15 #in ckancore
 messytables==0.15.2
 progressbar2==4.0.0


### PR DESCRIPTION
- XLoader needs to support XLSX. The long term solution is for XLoader to update from Messytables to Tabulator,
but for now we can just limit xlrd.