### PR TITLE
QOLDEV-1015 prepare for CKAN 2.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
             solr-version: "9"
             experimental: true  #master is unstable, good to know if we are compatible or not
 
-    name: Test on CKAN ${{ matrix.ckan-version }}
+    name: ${{ matrix.experimental && '**Fail_Ignored** ' || '' }} CKAN ${{ matrix.ckan-version }}
     runs-on: ubuntu-latest
     container: drevops/ci-runner:23.12.0
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,16 +26,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ckan-version: ["2.10", 2.9]
-        solr-version: ["8"]
+        ckan-version: ['2.10', 2.9]
+        solr-version: [8]
         experimental: [false]
         include:
           - ckan-version: '2.11'
-            solr-version: "9"
-            experimental: true  #testing compatibility for now
+            solr-version: 9
+            experimental: false
           - ckan-version: 'master'
-            solr-version: "9"
-            experimental: true  #master is unstable, good to know if we are compatible or not
+            solr-version: 9
+            experimental: true  # master is unstable, good to know if we are compatible or not
 
     name: ${{ matrix.experimental && '**Fail_Ignored** ' || '' }} CKAN ${{ matrix.ckan-version }}
     runs-on: ubuntu-latest

--- a/ckanext/qa/templates/package/read.html
+++ b/ckanext/qa/templates/package/read.html
@@ -1,0 +1,8 @@
+{% ckan_extends %}
+
+{% block package_notes %}
+    <section>
+      {{ h.qa_openness_stars_dataset_html(pkg) }}
+    </section>
+ {{ super() }}
+{% endblock %}


### PR DESCRIPTION
- Make CKAN 2.11 testing required
- Add a snippet to ensure that star ratings are applied to packages, not just resources.